### PR TITLE
feat: add support for squared conversions

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,10 @@ function isValidConversion (fromCategoryType, toCategoryType) {
     var errorSnippet =
       fromCategoryType === 'area'
         ? 'an area measurement to a length measurement'
-        : 'a length measurement to an area measurement';
+        : 'a length measurement to an area measurement'
     throw new Error(
       `Invalid conversion. You are trying to convert ${errorSnippet}.`
-    );
+    )
   }
 }
 
@@ -34,7 +34,7 @@ var modifiers = {
   ft2: 1,
   in: 12,
   in2: 144,
-};
+}
 
 var types = {
   mi: { value: 5280, category: 'length' },
@@ -43,7 +43,7 @@ var types = {
   ft2: { value: 1, category: 'area' },
   in: { value: 0.08333336, category: 'length' },
   in2: { value: 0.00694444, category: 'area' },
-};
+}
 
 function Pretty (value) {
   if (!(this instanceof Pretty)) {
@@ -62,49 +62,49 @@ Pretty.prototype.input = function (type) {
 }
 
 Pretty.prototype.mi = function () {
-  isValidConversion(this.type.category, 'length');
-  return prettify(this.value * this.type.value * modifiers.mi, this.prettify) + 'mi';
-};
+  isValidConversion(this.type.category, 'length')
+  return prettify(this.value * this.type.value * modifiers.mi, this.prettify) + 'mi'
+}
 
 Pretty.prototype.mi2 = function () {
-  isValidConversion(this.type.category, 'area');
-  return prettify(this.value * this.type.value * modifiers.mi2, this.prettify) + 'mi2';
-};
+  isValidConversion(this.type.category, 'area')
+  return prettify(this.value * this.type.value * modifiers.mi2, this.prettify) + 'mi2'
+}
 
 Pretty.prototype.ft = function () {
-  isValidConversion(this.type.category, 'length');
-  return prettify(this.value * this.type.value * modifiers.ft, this.prettify) + 'ft';
-};
+  isValidConversion(this.type.category, 'length')
+  return prettify(this.value * this.type.value * modifiers.ft, this.prettify) + 'ft'
+}
 
 Pretty.prototype.ft2 = function () {
-  isValidConversion(this.type.category, 'area');
-  return prettify(this.value * this.type.value * modifiers.ft2, this.prettify) + 'ft2';
-};
+  isValidConversion(this.type.category, 'area')
+  return prettify(this.value * this.type.value * modifiers.ft2, this.prettify) + 'ft2'
+}
 
 Pretty.prototype.in = function () {
-  isValidConversion(this.type.category, 'length');
-  return prettify(this.value * this.type.value * modifiers.in, this.prettify) + 'in';
-};
+  isValidConversion(this.type.category, 'length')
+  return prettify(this.value * this.type.value * modifiers.in, this.prettify) + 'in'
+}
 
 Pretty.prototype.in2 = function () {
-  isValidConversion(this.type.category, 'area');
-  return prettify(this.value * this.type.value * modifiers.in2, this.prettify) + 'in2';
-};
+  isValidConversion(this.type.category, 'area')
+  return prettify(this.value * this.type.value * modifiers.in2, this.prettify) + 'in2'
+}
 
 Pretty.prototype.humanize = function () {
-  var value = this.type.value * this.value;
-  var category = this.type.category;
-  this.prettify = true;
+  var value = this.type.value * this.value
+  var category = this.type.category
+  this.prettify = true
 
   if (category === 'area') {
-    if (value >= 27880000) return this.mi2();
+    if (value >= 27880000) return this.mi2()
     // necessary hack because of in2 to 1 ft2 conversion coming in just under 1
-    if (value >= 0.999) return this.ft2();
-    return this.in2();
+    if (value >= 0.999) return this.ft2()
+    return this.in2()
   }
-  if (value >= 5280) return this.mi();
-  if (value >= 1) return this.ft();
-  return this.in();
-};
+  if (value >= 5280) return this.mi()
+  if (value >= 1) return this.ft()
+  return this.in()
+}
 
 module.exports = Pretty

--- a/index.js
+++ b/index.js
@@ -8,17 +8,66 @@ function prettify (value, shouldPrettify) {
   return parts.join('.')
 }
 
-var modifiers = {
-	mi: 0.000189394,
-	ft: 1,
-	in: 12
+/**
+ * Utility for checking conversion validity
+ * Errors if a length measurement is trying to convert to an area measurement
+ * and vice versa
+ * @param {string} fromCategoryType the incoming category type i.e. length or area
+ * @param {string} toCategoryType the outbound category type i.e. length or area
+ */
+function isValidConversion (fromCategoryType, toCategoryType) {
+  if (fromCategoryType !== toCategoryType) {
+    var errorSnippet =
+      fromCategoryType === 'area'
+        ? 'an area measurement to a length measurement'
+        : 'a length measurement to an area measurement';
+    throw new Error(
+      `Invalid conversion. You are trying to convert ${errorSnippet}.`
+    );
+  }
 }
 
-var types = {
-  mi: 5280,
+var modifiers = {
+  mi: 0.000189394,
+  mi2: 0.00000003587,
   ft: 1,
-  in: 0.08333336
-}
+  ft2: 1,
+  in: 12,
+  in2: 144,
+};
+
+var types = {
+  mi: {
+    name: 'mi',
+    value: 5280,
+    category: 'length',
+  },
+  mi2: {
+    name: 'mi2',
+    value: 27880000,
+    category: 'area',
+  },
+  ft: {
+    name: 'ft',
+    value: 1,
+    category: 'length',
+  },
+  ft2: {
+    name: 'ft2',
+    value: 1,
+    category: 'area',
+  },
+  in: {
+    name: 'in',
+    value: 0.08333336,
+    category: 'length',
+  },
+  in2: {
+    name: 'in2',
+    value: 0.00694444,
+    category: 'area',
+  },
+};
 
 function Pretty (value) {
   if (!(this instanceof Pretty)) {
@@ -37,23 +86,64 @@ Pretty.prototype.input = function (type) {
 }
 
 Pretty.prototype.mi = function () {
-  return prettify((this.value * this.type) * modifiers.mi, this.prettify) + 'mi'
-}
+  isValidConversion(this.type.category, 'length');
+  return (
+    prettify(this.value * this.type.value * modifiers.mi, this.prettify) + 'mi'
+  );
+};
+
+Pretty.prototype.mi2 = function () {
+  isValidConversion(this.type.category, 'area');
+  return (
+    prettify(this.value * this.type.value * modifiers.mi2, this.prettify) +
+    'mi2'
+  );
+};
 
 Pretty.prototype.ft = function () {
-  return prettify((this.value * this.type) * modifiers.ft, this.prettify) + 'ft'
-}
+  isValidConversion(this.type.category, 'length');
+  return (
+    prettify(this.value * this.type.value * modifiers.ft, this.prettify) + 'ft'
+  );
+};
+
+Pretty.prototype.ft2 = function () {
+  isValidConversion(this.type.category, 'area');
+  return (
+    prettify(this.value * this.type.value * modifiers.ft2, this.prettify) +
+    'ft2'
+  );
+};
 
 Pretty.prototype.in = function () {
-  return prettify((this.value * this.type) * modifiers.in, this.prettify) + 'in'
-}
+  isValidConversion(this.type.category, 'length');
+  return (
+    prettify(this.value * this.type.value * modifiers.in, this.prettify) + 'in'
+  );
+};
+
+Pretty.prototype.in2 = function () {
+  isValidConversion(this.type.category, 'area');
+  return (
+    prettify(this.value * this.type.value * modifiers.in2, this.prettify) +
+    'in2'
+  );
+};
 
 Pretty.prototype.humanize = function () {
-  var value = this.type * this.value
-  this.prettify = true
-  if (value >= 5280) return this.mi()
-  if (value >= 1) return this.ft()
-  return this.in()
-}
+  var value = this.type.value * this.value;
+  var category = this.type.category;
+  this.prettify = true;
+
+  if (category === 'area') {
+    if (value >= 27880000) return this.mi2();
+    // necessary hack because of in2 to ft2 conversion coming in just under 1
+    if (value >= 0.999) return this.ft2();
+    return this.in2();
+  }
+  if (value >= 5280) return this.mi();
+  if (value >= 1) return this.ft();
+  return this.in();
+};
 
 module.exports = Pretty

--- a/index.js
+++ b/index.js
@@ -38,32 +38,26 @@ var modifiers = {
 
 var types = {
   mi: {
-    name: 'mi',
     value: 5280,
     category: 'length',
   },
   mi2: {
-    name: 'mi2',
     value: 27880000,
     category: 'area',
   },
   ft: {
-    name: 'ft',
     value: 1,
     category: 'length',
   },
   ft2: {
-    name: 'ft2',
     value: 1,
     category: 'area',
   },
   in: {
-    name: 'in',
     value: 0.08333336,
     category: 'length',
   },
   in2: {
-    name: 'in2',
     value: 0.00694444,
     category: 'area',
   },

--- a/index.js
+++ b/index.js
@@ -37,30 +37,12 @@ var modifiers = {
 };
 
 var types = {
-  mi: {
-    value: 5280,
-    category: 'length',
-  },
-  mi2: {
-    value: 27880000,
-    category: 'area',
-  },
-  ft: {
-    value: 1,
-    category: 'length',
-  },
-  ft2: {
-    value: 1,
-    category: 'area',
-  },
-  in: {
-    value: 0.08333336,
-    category: 'length',
-  },
-  in2: {
-    value: 0.00694444,
-    category: 'area',
-  },
+  mi: { value: 5280, category: 'length' },
+  mi2: { value: 27880000, category: 'area' },
+  ft: { value: 1, category: 'length' },
+  ft2: { value: 1, category: 'area' },
+  in: { value: 0.08333336, category: 'length' },
+  in2: { value: 0.00694444, category: 'area' },
 };
 
 function Pretty (value) {

--- a/index.js
+++ b/index.js
@@ -87,47 +87,32 @@ Pretty.prototype.input = function (type) {
 
 Pretty.prototype.mi = function () {
   isValidConversion(this.type.category, 'length');
-  return (
-    prettify(this.value * this.type.value * modifiers.mi, this.prettify) + 'mi'
-  );
+  return prettify(this.value * this.type.value * modifiers.mi, this.prettify) + 'mi';
 };
 
 Pretty.prototype.mi2 = function () {
   isValidConversion(this.type.category, 'area');
-  return (
-    prettify(this.value * this.type.value * modifiers.mi2, this.prettify) +
-    'mi2'
-  );
+  return prettify(this.value * this.type.value * modifiers.mi2, this.prettify) + 'mi2';
 };
 
 Pretty.prototype.ft = function () {
   isValidConversion(this.type.category, 'length');
-  return (
-    prettify(this.value * this.type.value * modifiers.ft, this.prettify) + 'ft'
-  );
+  return prettify(this.value * this.type.value * modifiers.ft, this.prettify) + 'ft';
 };
 
 Pretty.prototype.ft2 = function () {
   isValidConversion(this.type.category, 'area');
-  return (
-    prettify(this.value * this.type.value * modifiers.ft2, this.prettify) +
-    'ft2'
-  );
+  return prettify(this.value * this.type.value * modifiers.ft2, this.prettify) + 'ft2';
 };
 
 Pretty.prototype.in = function () {
   isValidConversion(this.type.category, 'length');
-  return (
-    prettify(this.value * this.type.value * modifiers.in, this.prettify) + 'in'
-  );
+  return prettify(this.value * this.type.value * modifiers.in, this.prettify) + 'in';
 };
 
 Pretty.prototype.in2 = function () {
   isValidConversion(this.type.category, 'area');
-  return (
-    prettify(this.value * this.type.value * modifiers.in2, this.prettify) +
-    'in2'
-  );
+  return prettify(this.value * this.type.value * modifiers.in2, this.prettify) + 'in2';
 };
 
 Pretty.prototype.humanize = function () {
@@ -137,7 +122,7 @@ Pretty.prototype.humanize = function () {
 
   if (category === 'area') {
     if (value >= 27880000) return this.mi2();
-    // necessary hack because of in2 to ft2 conversion coming in just under 1
+    // necessary hack because of in2 to 1 ft2 conversion coming in just under 1
     if (value >= 0.999) return this.ft2();
     return this.in2();
   }

--- a/test/humanize.js
+++ b/test/humanize.js
@@ -1,41 +1,42 @@
-var test = require('ava');
-var pretty = require('..');
+var test = require('ava')
+var pretty = require('..')
 
 test('humanize feet to mile', function (t) {
-  t.is(pretty(15000).humanize(), '2.84mi');
-});
+  t.is(pretty(15000).humanize(), '2.84mi')
+})
 
 test('humanize square feet to mile', function (t) {
-  t.is(pretty(27880000).input('ft2').humanize(), '1mi2');
-});
+  t.is(pretty(27880000).input('ft2').humanize(), '1mi2')
+})
 
 test('humanize feet to ft', function (t) {
-  t.is(pretty(1.5).humanize(), '1.5ft');
-});
+  t.is(pretty(1.5).humanize(), '1.5ft')
+})
 
 test('humanize ft to inch', function (t) {
-  t.is(pretty(0.5).humanize(), '6in');
-});
+  t.is(pretty(0.5).humanize(), '6in')
+})
 
 test('input: humanize in', function (t) {
-  t.is(pretty(120).input('in').humanize(), '10ft');
-});
+  t.is(pretty(120).input('in').humanize(), '10ft')
+})
 
 test('input: humanize in', function (t) {
-  t.is(pretty(6).input('in').humanize(), '6in');
-});
+  t.is(pretty(6).input('in').humanize(), '6in')
+})
 
 test('input: humanize square in', function (t) {
-  t.is(pretty(144).input('in2').humanize(), '1ft2');
-});
+  t.is(pretty(144).input('in2').humanize(), '1ft2')
+})
 
 test('input: humanize square in', function (t) {
-  t.is(pretty(100).input('in2').humanize(), '100in2');
-});
+  t.is(pretty(100).input('in2').humanize(), '100in2')
+})
 
 test('input: humanize decimal in', function (t) {
-  t.is(pretty(0.4).input('in').humanize(), '0.4in');
-});
+  t.is(pretty(0.4).input('in').humanize(), '0.4in')
+})
+
 test('input: humanize zero', function (t) {
-  t.is(pretty(0).input('in').humanize(), '0in');
-});
+  t.is(pretty(0).input('in').humanize(), '0in')
+})

--- a/test/humanize.js
+++ b/test/humanize.js
@@ -1,29 +1,41 @@
-var test = require('ava')
-var pretty = require('..')
+var test = require('ava');
+var pretty = require('..');
 
 test('humanize feet to mile', function (t) {
-  t.is(pretty(15000).humanize(), '2.84mi')
-})
+  t.is(pretty(15000).humanize(), '2.84mi');
+});
+
+test('humanize square feet to mile', function (t) {
+  t.is(pretty(27880000).input('ft2').humanize(), '1mi2');
+});
 
 test('humanize feet to ft', function (t) {
-  t.is(pretty(1.5).humanize(), '1.5ft')
-})
+  t.is(pretty(1.5).humanize(), '1.5ft');
+});
 
 test('humanize ft to inch', function (t) {
-  t.is(pretty(.5).humanize(), '6in')
-})
+  t.is(pretty(0.5).humanize(), '6in');
+});
 
 test('input: humanize in', function (t) {
-  t.is(pretty(120).input('in').humanize(), '10ft')
-})
+  t.is(pretty(120).input('in').humanize(), '10ft');
+});
 
 test('input: humanize in', function (t) {
-  t.is(pretty(6).input('in').humanize(), '6in')
-})
+  t.is(pretty(6).input('in').humanize(), '6in');
+});
+
+test('input: humanize square in', function (t) {
+  t.is(pretty(144).input('in2').humanize(), '1ft2');
+});
+
+test('input: humanize square in', function (t) {
+  t.is(pretty(100).input('in2').humanize(), '100in2');
+});
 
 test('input: humanize decimal in', function (t) {
-  t.is(pretty(0.4).input('in').humanize(), '0.4in')
-})
+  t.is(pretty(0.4).input('in').humanize(), '0.4in');
+});
 test('input: humanize zero', function (t) {
-  t.is(pretty(0).input('in').humanize(), '0in')
-})
+  t.is(pretty(0).input('in').humanize(), '0in');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,24 +1,72 @@
-var test = require('ava')
-var pretty = require('..')
+var test = require('ava');
+var pretty = require('..');
 test('default 1 foot to ft', function (t) {
-  t.is(pretty().ft(), '1ft')
-})
+  t.is(pretty().ft(), '1ft');
+});
 
+// inch conversions
 test('inch to ft', function (t) {
-  t.is(pretty(1).input('in').ft(), '0.08333336ft')
-})
-test('foot to mi', function (t) {
-  t.is(pretty(7000).mi(), '1.325758mi')
-})
+  t.is(pretty(1).input('in').ft(), '0.08333336ft');
+});
+test('inch to mile', function (t) {
+  t.is(pretty(1500).input('in').mi(), '0.02367425757576mi');
+});
 
+// square inch conversions
+test('square inch to square ft', function (t) {
+  t.is(pretty(1).input('in2').ft2(), '0.00694444ft2');
+});
+test('square inch to square mile', function (t) {
+  t.is(pretty(100000).input('in2').mi2(), '0.00002490970628mi2');
+});
+
+// foot conversions
 test('foot to ft', function (t) {
-  t.is(pretty(12).ft(), '12ft')
-})
-
+  t.is(pretty(12).ft(), '12ft');
+});
 test('feet to inch', function (t) {
-  t.is(pretty(150).in(), '1800in')
-})
+  t.is(pretty(1).in(), '12in');
+});
+test('foot to mi', function (t) {
+  t.is(pretty(7000).mi(), '1.325758mi');
+});
 
-test('input: in to mi', function (t) {
-  t.is(pretty(1500).input('in').mi(), '0.02367425757576mi')
-})
+// square foot conversions
+test('square ft to square inch', function (t) {
+  t.is(pretty(1).input('ft2').in2(), '144in2');
+});
+test('square ft to square miles', function (t) {
+  t.is(pretty(10000).input('ft2').mi2(), '0.00035870000000000005mi2');
+});
+
+// mile conversions
+test('miles to inches', function (t) {
+  t.is(pretty(1).input('mi').in(), '63360in');
+});
+test('miles to feet', function (t) {
+  t.is(pretty(1).input('mi').ft(), '5280ft');
+});
+
+// square mile conversions
+test('square miles to square inches', function (t) {
+  t.is(pretty(1).input('mi2').in2(), '4014720000in2');
+});
+test('square miles to square feet', function (t) {
+  t.is(pretty(1).input('mi2').ft2(), '27880000ft2');
+});
+
+// invalid conversions
+test('converting from length to area throws error', function (t) {
+  const error = t.throws(() => pretty(1).input('ft').mi2());
+  t.is(
+    error.message,
+    'Invalid conversion. You are trying to convert a length measurement to an area measurement.'
+  );
+});
+test('converting from area to length throws error', function (t) {
+  const error = t.throws(() => pretty(1).input('mi2').ft());
+  t.is(
+    error.message,
+    'Invalid conversion. You are trying to convert an area measurement to a length measurement.'
+  );
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,72 +1,73 @@
-var test = require('ava');
-var pretty = require('..');
+var test = require('ava')
+var pretty = require('..')
+
 test('default 1 foot to ft', function (t) {
-  t.is(pretty().ft(), '1ft');
-});
+  t.is(pretty().ft(), '1ft')
+})
 
 // inch conversions
 test('inch to ft', function (t) {
-  t.is(pretty(1).input('in').ft(), '0.08333336ft');
-});
+  t.is(pretty(1).input('in').ft(), '0.08333336ft')
+})
 test('inch to mile', function (t) {
-  t.is(pretty(1500).input('in').mi(), '0.02367425757576mi');
-});
+  t.is(pretty(1500).input('in').mi(), '0.02367425757576mi')
+})
 
 // square inch conversions
 test('square inch to square ft', function (t) {
-  t.is(pretty(1).input('in2').ft2(), '0.00694444ft2');
-});
+  t.is(pretty(1).input('in2').ft2(), '0.00694444ft2')
+})
 test('square inch to square mile', function (t) {
-  t.is(pretty(100000).input('in2').mi2(), '0.00002490970628mi2');
-});
+  t.is(pretty(100000).input('in2').mi2(), '0.00002490970628mi2')
+})
 
 // foot conversions
 test('foot to ft', function (t) {
-  t.is(pretty(12).ft(), '12ft');
-});
+  t.is(pretty(12).ft(), '12ft')
+})
 test('feet to inch', function (t) {
-  t.is(pretty(1).in(), '12in');
-});
+  t.is(pretty(1).in(), '12in')
+})
 test('foot to mi', function (t) {
-  t.is(pretty(7000).mi(), '1.325758mi');
-});
+  t.is(pretty(7000).mi(), '1.325758mi')
+})
 
 // square foot conversions
 test('square ft to square inch', function (t) {
-  t.is(pretty(1).input('ft2').in2(), '144in2');
-});
+  t.is(pretty(1).input('ft2').in2(), '144in2')
+})
 test('square ft to square miles', function (t) {
-  t.is(pretty(10000).input('ft2').mi2(), '0.00035870000000000005mi2');
-});
+  t.is(pretty(10000).input('ft2').mi2(), '0.00035870000000000005mi2')
+})
 
 // mile conversions
 test('miles to inches', function (t) {
-  t.is(pretty(1).input('mi').in(), '63360in');
-});
+  t.is(pretty(1).input('mi').in(), '63360in')
+})
 test('miles to feet', function (t) {
-  t.is(pretty(1).input('mi').ft(), '5280ft');
-});
+  t.is(pretty(1).input('mi').ft(), '5280ft')
+})
 
 // square mile conversions
 test('square miles to square inches', function (t) {
-  t.is(pretty(1).input('mi2').in2(), '4014720000in2');
-});
+  t.is(pretty(1).input('mi2').in2(), '4014720000in2')
+})
 test('square miles to square feet', function (t) {
-  t.is(pretty(1).input('mi2').ft2(), '27880000ft2');
-});
+  t.is(pretty(1).input('mi2').ft2(), '27880000ft2')
+})
 
 // invalid conversions
 test('converting from length to area throws error', function (t) {
-  const error = t.throws(() => pretty(1).input('ft').mi2());
+  const error = t.throws(() => pretty(1).input('ft').mi2())
   t.is(
     error.message,
     'Invalid conversion. You are trying to convert a length measurement to an area measurement.'
-  );
-});
+  )
+})
 test('converting from area to length throws error', function (t) {
-  const error = t.throws(() => pretty(1).input('mi2').ft());
+  const error = t.throws(() => pretty(1).input('mi2').ft())
   t.is(
     error.message,
     'Invalid conversion. You are trying to convert an area measurement to a length measurement.'
-  );
-});
+  )
+})


### PR DESCRIPTION
### Overview

Discovered this morning that converting between units like feet to miles requires different conversion factors than converting between square feet and square miles. This PR covers the work required to support squared unit conversions. The following updates were made:

- add modifiers for mi2, ft2, and in2
- restructure the `types` variable so measurement type (i.e. length or area) can be captured along with the conversion factor
- add validation utility to throw error if user tries to convert from a length to a measurement and vice versa
- add converters for mi2, ft2, and in2,
- add logic to humanize for squared units
- add tests for squared units